### PR TITLE
Correctly bring up F2FS support

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -5,21 +5,26 @@
 #TODO: Add 'check' as fs_mgr_flags with data partition.
 # Currently we dont have e2fsck compiled. So fs check would failed.
 
-#<src>                                                 <mnt_point>               <type>  <mnt_flags and options>                            <fs_mgr_flags>
-/dev/block/bootdevice/by-name/system                    /                        ext4    ro,barrier=1,discard                                 wait,avb
+#<src>                                                  <mnt_point>              <type>  <mnt_flags and options>                                                                          <fs_mgr_flags>
+//dev/block/bootdevice/by-name/system                    /                        ext4    ro,barrier=1,discard                                 wait,avb
 /dev/block/bootdevice/by-name/vendor                    /vendor                  ext4    ro,barrier=1                                                                                      wait,recoveryonly
 /dev/block/bootdevice/by-name/userdata                  /data                    ext4    noatime,nosuid,nodev,barrier=1,noauto_da_alloc,lazytime       latemount,wait,check,formattable,fileencryption=ice,reservedsize=128M,quota
-/dev/block/bootdevice/by-name/userdata                  /data                    f2fs    noatime,nosuid,nodev,rw,inline_xattr            latemount,wait,check,formattable,encryptable=footer,reservedsize=512M,quota
+/dev/block/bootdevice/by-name/userdata                  /data                    f2fs    noatime,nosuid,nodev,discard,background_gc=sync,fsync_mode=nobarrier                             latemount,wait,check,fileencryption=ice,quota,formattable,reservedsize=128M
 /dev/block/bootdevice/by-name/cache                     /cache                   ext4    nosuid,noatime,nodev,barrier=1                         wait,check
-/dev/block/bootdevice/by-name/cache			/cache			 f2fs	 noatime,nosuid,nodev,rw,inline_xattr			wait,check
+/dev/block/bootdevice/by-name/cache                     /cache                   f2fs    nosuid,nodev,noatime,inline_xattr                                                                wait,check,formattable
 /dev/block/bootdevice/by-name/boot                      /boot                    emmc    defaults                                                                                          recoveryonly
 /dev/block/bootdevice/by-name/recovery                  /recovery                emmc    defaults                                                                                          recoveryonly
 /dev/block/bootdevice/by-name/modem                     /vendor/firmware_mnt     vfat    ro,shortname=lower,uid=0,gid=1000,dmask=227,fmask=337 wait
 /dev/block/bootdevice/by-name/dsp                       /vendor/dsp              ext4    ro,nosuid,nodev,barrier=1                            wait
 /dev/block/bootdevice/by-name/persist                   /mnt/vendor/persist      ext4    nosuid,noatime,nodev,barrier=1                               wait,check
 /dev/block/bootdevice/by-name/bluetooth                 /vendor/bt_firmware      vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337 wait
+
 # Need to have this entry in here even though the mount point itself is no longer needed.
 # The update_engine code looks for this entry in order to determine the boot device address
 # and fails if it does not find it.
 /dev/block/bootdevice/by-name/misc                      /misc              emmc    defaults                                             defaults
 /devices/platform/soc/a600000.ssusb/a600000.dwc3/xhci-hcd.*.auto*     /storage/usbotg    vfat    nosuid,nodev    wait,voldmanaged=usbotg:auto
+
+/dev/block/bootdevice/by-name/misc                      /misc                    emmc    defaults                                                                                         defaults
+/dev/block/bootdevice/by-name/boot                      /boot                    emmc    defaults                                                                                         defaults
+/dev/block/bootdevice/by-name/recovery                  /recovery   

--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -6,7 +6,7 @@
 # Currently we dont have e2fsck compiled. So fs check would failed.
 
 #<src>                                                  <mnt_point>              <type>  <mnt_flags and options>                                                                          <fs_mgr_flags>
-//dev/block/bootdevice/by-name/system                    /                        ext4    ro,barrier=1,discard                                 wait,avb
+/dev/block/bootdevice/by-name/system                    /                        ext4    ro,barrier=1,discard                                 wait,avb
 /dev/block/bootdevice/by-name/vendor                    /vendor                  ext4    ro,barrier=1                                                                                      wait,recoveryonly
 /dev/block/bootdevice/by-name/userdata                  /data                    ext4    noatime,nosuid,nodev,barrier=1,noauto_da_alloc,lazytime       latemount,wait,check,formattable,fileencryption=ice,reservedsize=128M,quota
 /dev/block/bootdevice/by-name/userdata                  /data                    f2fs    noatime,nosuid,nodev,discard,background_gc=sync,fsync_mode=nobarrier                             latemount,wait,check,fileencryption=ice,quota,formattable,reservedsize=128M

--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -24,7 +24,3 @@
 # and fails if it does not find it.
 /dev/block/bootdevice/by-name/misc                      /misc              emmc    defaults                                             defaults
 /devices/platform/soc/a600000.ssusb/a600000.dwc3/xhci-hcd.*.auto*     /storage/usbotg    vfat    nosuid,nodev    wait,voldmanaged=usbotg:auto
-
-/dev/block/bootdevice/by-name/misc                      /misc                    emmc    defaults                                                                                         defaults
-/dev/block/bootdevice/by-name/boot                      /boot                    emmc    defaults                                                                                         defaults
-/dev/block/bootdevice/by-name/recovery                  /recovery   


### PR DESCRIPTION
In order for a correct Filesystem bringup, there were missing a few flags and options.
That is, those missing flags were causing an incorrect encryption while at the same time making the device unlockable. Those missing flags fixes the problem!
Thanks to ElPaablo and Oleks especially (It's extracted from his fix in the CrDroid for Mi9SE's group)